### PR TITLE
checkFileDataBeforeRetrieval: fix error in case additional_types is not set

### DIFF
--- a/src/Service/BlobService.php
+++ b/src/Service/BlobService.php
@@ -1067,7 +1067,7 @@ class BlobService
     public function getJsonSchemaStorageWithAllSchemasInABucket(Bucket $bucket): SchemaStorage
     {
         $schemaStorage = new SchemaStorage();
-        foreach ($bucket->getAdditionalTypes() as $type => $path) {
+        foreach (($bucket->getAdditionalTypes() ?? []) as $type => $path) {
             $jsonSchemaObject = json_decode(file_get_contents($path));
 
             if ($jsonSchemaObject === null) {


### PR DESCRIPTION
In case the bucket config has no additional_types then getAdditionalTypes() return null which makes things fail.

Just ignore it if that is the case.